### PR TITLE
Supporting user customization of setup() function in TinyMCE

### DIFF
--- a/src/js/xsltforms.js/controls/input.js
+++ b/src/js/xsltforms.js/controls/input.js
@@ -108,8 +108,10 @@ XsltForms_input.prototype.initInput = function(type) {
 					if (!XsltForms_globals.tinyMCEinit || XsltForms_globals.jslibraries["http://www.tinymce.com"].substr(0, 2) !== "3.") {
 						eval("initinfo = " + (type.appinfo ? type.appinfo.replace(/(\r\n|\n|\r)/gm, " ") : "{}"));
 						initinfo.mode = "none";
+						initinfo.Xsltforms_usersetup = (initinfo.setup ? initinfo.setup : function (ed) {} ) // if user supplies setup(), move it out of the way;
 						if (!XsltForms_globals.jslibraries["http://www.tinymce.com"] || XsltForms_globals.jslibraries["http://www.tinymce.com"].substr(0, 2) === "3.") {
 							initinfo.setup = function(ed) {
+								initinfo.Xsltforms_usersetup(ed); // call user's setup()
 								ed.onKeyUp.add(function(ed) {
 									XsltForms_control.getXFElement(document.getElementById(ed.id)).valueChanged(ed.getContent() || "");
 								});
@@ -125,6 +127,7 @@ XsltForms_input.prototype.initInput = function(type) {
 							};
 						} else {
 							initinfo.setup = function(ed) {
+								initinfo.Xsltforms_usersetup(ed); // call user's setup()
 								ed.on("KeyUp", function() {
 									XsltForms_control.getXFElement(document.getElementById(this.id)).valueChanged(this.getContent() || "");
 								});

--- a/src/js/xsltforms2.js/controls/input.js
+++ b/src/js/xsltforms2.js/controls/input.js
@@ -110,8 +110,10 @@ XsltForms_input.initInput = function(type) {
 					if (!XsltForms_engine.tinyMCEinit || XsltForms_engine.jslibraries["http://www.tinymce.com"].substr(0, 2) !== "3.") {
 						eval("initinfo = " + (type.appinfo ? type.appinfo.replace(/(\r\n|\n|\r)/gm, " ") : "{}"));
 						initinfo.mode = "none";
+						initinfo.Xsltforms_usersetup = (initinfo.setup ? initinfo.setup : function (ed) {} ); // if user provide setup(), move it out of the way
 						if (!XsltForms_engine.jslibraries["http://www.tinymce.com"] || XsltForms_engine.jslibraries["http://www.tinymce.com"].substr(0, 2) === "3.") {
 							initinfo.setup = function(ed) {
+								initinfo.Xsltforms_usersetup(ed); // call user's setup()
 								ed.onKeyUp.add(function(ed) {
 									XsltForms_control.getXFElement(document.getElementById(ed.id)).valueChanged(ed.getContent() || "");
 								});
@@ -127,6 +129,7 @@ XsltForms_input.initInput = function(type) {
 							};
 						} else {
 							initinfo.setup = function(ed) {
+								initinfo.Xsltforms_usersetup(ed); // call user's setup()
 								ed.on("KeyUp", function() {
 									XsltForms_control.getXFElement(document.getElementById(this.id)).valueChanged(this.getContent() || "");
 								});


### PR DESCRIPTION
Some customizations of TinyMCE (for example, making custom buttons) requires that the user supply a `setup()` function as part of the initialization object passed to TinyMCE as the argument of `tinymce.init()`.

In XSLTForms, the user supplies the initialization object as the content of an `xsd:appinfo` element in the declaration of a simple type to be bound to the element to be edited using TinyMCE.  XSLTForms then passes the object to TinyMCE when XSLTForms calls `tinymce.init()`.

However, the existing XSLTForms code assigns its own function to the `setup` property, so if the user has provided a `setup()` function, it's lost.  Attempts to define custom buttons for the TinyMCE editor fail.

This patch introduces a change to (a) move the user's `setup` property to a different name (`Xsltforms_usersetup`) and (b) call `initobject.Xsltforms_usersetup(ed)` from the `setup()` function it supplies to TinyMCE.  User definitions of custom buttons for the TinyMCE editor now succeed.