### PR TITLE
also try ctx.env.nsresolver.lookupNamespaceURI on attributes

### DIFF
--- a/build/js/fleur.js
+++ b/build/js/fleur.js
@@ -14578,7 +14578,7 @@ Fleur.XQueryEngine[Fleur.XQueryX.attributeConstructor] = function(ctx, children,
 	} else {
 		attr.prefix = null;
 	}
-	attr.namespaceURI = elt.lookupNamespaceURI(attr.prefix);
+	attr.namespaceURI = elt.lookupNamespaceURI(attr.prefix) || ctx.env.nsresolver.lookupNamespaceURI(attr.prefix);
 	if (children[1][0] === Fleur.XQueryX.attributeValue) {
 		if (children[1][1].length !== 0) {
 			t = new Fleur.Text();

--- a/src/js/fleur.js/XQuery/Instructions/attributeConstructor.js
+++ b/src/js/fleur.js/XQuery/Instructions/attributeConstructor.js
@@ -55,7 +55,7 @@ Fleur.XQueryEngine[Fleur.XQueryX.attributeConstructor] = function(ctx, children,
   } else {
     attr.prefix = null;
   }
-  attr.namespaceURI = elt.lookupNamespaceURI(attr.prefix);
+  attr.namespaceURI = elt.lookupNamespaceURI(attr.prefix) || ctx.env.nsresolver.lookupNamespaceURI(attr.prefix);
   if (children[1][0] === Fleur.XQueryX.attributeValue) {
     if (children[1][1].length !== 0) {
       t = new Fleur.Text();


### PR DESCRIPTION
This PR fixes the issue of declared namespaces not being applied on attributes, e.g. when running
```
declare namespace myprefix="http://mansoft.nl/myprefix";

<myprefix:element myprefix:attr="value"/>
```
in xquerytests/runany.htm and looking at res._result attr did not have a namespaceURI, while element its namespaceURI equaled "http://mansoft.nl/myprefix". Now namespaceURI equals "http://mansoft.nl/myprefix" both on element and attr