### PR TITLE
copy pf and uri from current nsresolver when creating a new one

### DIFF
--- a/src/js/fleur.js/XQuery/Instructions/elementConstructor.js
+++ b/src/js/fleur.js/XQuery/Instructions/elementConstructor.js
@@ -72,11 +72,11 @@ Fleur.XQueryEngine[Fleur.XQueryX.elementConstructor] = function(ctx, children, c
         var nsr = ctx.env.nsresolver;
         ctx.env.nsresolver = new Fleur.XPathNSResolver(elt);
         if (nsr.nsresolver) {
-          ctx.env.nsresolver.pf = nsr.nsresolver.pf;
-          ctx.env.nsresolver.uri = nsr.nsresolver.uri;
+          ctx.env.nsresolver.pf = nsr.nsresolver.pf.slice(0);
+          ctx.env.nsresolver.uri = nsr.nsresolver.uri.slice(0);
         } else {
-          ctx.env.nsresolver.pf = nsr.pf;
-          ctx.env.nsresolver.uri = nsr.uri;
+          ctx.env.nsresolver.pf = nsr.pf.slice(0);
+          ctx.env.nsresolver.uri = nsr.uri.slice(0);
         }
         Fleur.XQueryEngine[children[2][0]](ctx, children[2][1], function(n) {
           ctx.env.nsresolver = nsr;

--- a/src/js/fleur.js/XQuery/Instructions/elementConstructor.js
+++ b/src/js/fleur.js/XQuery/Instructions/elementConstructor.js
@@ -71,6 +71,13 @@ Fleur.XQueryEngine[Fleur.XQueryX.elementConstructor] = function(ctx, children, c
       if (children.length > 2) {
         var nsr = ctx.env.nsresolver;
         ctx.env.nsresolver = new Fleur.XPathNSResolver(elt);
+        if (nsr.nsresolver) {
+          ctx.env.nsresolver.pf = nsr.nsresolver.pf;
+          ctx.env.nsresolver.uri = nsr.nsresolver.uri;
+        } else {
+          ctx.env.nsresolver.pf = nsr.pf;
+          ctx.env.nsresolver.uri = nsr.uri;
+        }
         Fleur.XQueryEngine[children[2][0]](ctx, children[2][1], function(n) {
           ctx.env.nsresolver = nsr;
           Fleur.callback(function() {callback(n);});


### PR DESCRIPTION
When creating a new Fleur.XPathNSResolver the pf an uri members, which among others contain the declared namespaces in the prolog, of the current resolver should be copied